### PR TITLE
csp: Update bignumber to not use unsafe-eval

### DIFF
--- a/bignumber.js
+++ b/bignumber.js
@@ -2717,7 +2717,7 @@
     // Browser.
     } else {
         if ( !globalObject ) {
-            globalObject = typeof self != 'undefined' ? self : Function('return this')();
+            globalScope = typeof self != 'undefined' && self ? self : window;
         }
 
         globalObject.BigNumber = BigNumber;


### PR DESCRIPTION
Update bignumber to prevent violating unsafe-eval [csp](https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-eval) rule for all libraries that use it. 

![image](https://user-images.githubusercontent.com/5531981/38156546-971fba74-3433-11e8-90ec-7185d09027ec.png)

